### PR TITLE
Fix slow response

### DIFF
--- a/lib/express.js
+++ b/lib/express.js
@@ -37,7 +37,7 @@ module.exports = function initialize (adapter, opts) {
   }
 
   let maxResults = 100000
-  let chunkSize = 10
+  let chunkSize = 10000
   let resultSizeMax = 200
   if (process.env.MAX_ROWS_LEVELDB) {
     try {


### PR DESCRIPTION
**Problem:**

`curl -XGET localhost:8432/a/1AuGvfDfNhbeVNUDzXHjLmEnFnWv3pkjjG/utxos`

Response time: ~60 seconds or time out.

**Debug:**
To get utxos, we searchRange all blocks by addressToScriptID:
If latest block is ~1M6.  Split all blocks to n time to hit db by chunkSize. 
Example, latest block is ~1M6. / chunkSize(10) = 160k times.
i found that chunkSize too small, hit to leveldb too much.
Reduce n to help reduce response time

**Solution:**
I tried to increase chunkSize value to 100, 1000, 10_000 and 100_000. 
Benchmark show that with chunkSize = 10_000 return good response Time
< 1 seconds on mainnet

```
$ time curl localhost:8432/a/1AuGvfDfNhbeVNUDzXHjLmEnFnWv3pkjjG/utxos
real	0m0.638s
user	0m0.005s
sys	0m0.015s

$ time curl localhost:8432/a/1Afb76aMKPTpSppV9nZrf3Nfmg4KXvikeA/utxos
real	0m0.169s
user	0m0.006s
sys	0m0.005s

$ time curl localhost:8432/a/19s5TAWJNdsRxzoHN51TPsWnCieD2h1M1y/utxos
real	0m0.090s
user	0m0.006s
sys	0m0.004s
``` 